### PR TITLE
Right-aligned labels on new account screen.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "cwd": "${fileDirname}"
+        }
+    ]
+}

--- a/Game/gui.kv
+++ b/Game/gui.kv
@@ -239,6 +239,8 @@
                         text: "Username:"
                         font_size: dp(24)
                         color: (1, .5, 0, 1)
+                        halign: "right"
+                        text_size: self.size
 
                     TextInput:
                         id: NewUsername
@@ -260,6 +262,8 @@
                         text: "Password:"
                         font_size: dp(24)
                         color: (1, .5, 0, 1)
+                        halign: "right"
+                        text_size: self.size
 
                     TextInput:
                         id: NewPassword
@@ -282,6 +286,7 @@
                         text: "Confirm Password:"
                         font_size: dp(24)
                         color: (1, .5, 0, 1)
+                        halign: "right"
 
                     TextInput:
                         id: ConfirmPassword
@@ -304,6 +309,8 @@
                         text: "Email:"
                         font_size: dp(24)
                         color: (1, .5, 0, 1)
+                        halign: "right"
+                        text_size: self.size
 
                     TextInput:
                         id: NewEmail
@@ -325,6 +332,8 @@
                         text: "Question:"
                         font_size: dp(24)
                         color: (1, .5, 0, 1)
+                        halign: "right"
+                        text_size: self.size
 
                     TextInput:
                         id: NewQuestion
@@ -346,6 +355,8 @@
                         text: "Answer:"
                         font_size: dp(24)
                         color: (1, .5, 0, 1)
+                        halign: "right"
+                        text_size: self.size
 
                     TextInput:
                         id: NewAnswer


### PR DESCRIPTION
I have updated the labels on the new account screen so that they are now right-aligned. However, the "Confirm Password" label cannot be aligned to the right.